### PR TITLE
iOS: allows http api call

### DIFF
--- a/ios/dev_quiz_mobile/Info.plist
+++ b/ios/dev_quiz_mobile/Info.plist
@@ -26,14 +26,8 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string/>


### PR DESCRIPTION
Edit **Info.plist** to allow **http** when making API calls. XCode blocks unsecured http requests. 

Don't forget to: **pod install, pod update**, and **run the app on XCode** if cannot run from terminal. 

![image](https://user-images.githubusercontent.com/50040948/160278648-a63698b4-6396-4ec2-9fa8-155e26917a97.png)
