### PR TITLE
Axios Config: fix asynchronous error

### DIFF
--- a/src/configuration/Axios.configuration.js
+++ b/src/configuration/Axios.configuration.js
@@ -1,5 +1,6 @@
 import Axios from 'axios';
 import {getData} from '../utilities/localStorage';
+import {TOKEN_KEY} from '../context/AppContext' 
 
 let quizAPI = Axios.create({
   baseURL:
@@ -8,7 +9,7 @@ let quizAPI = Axios.create({
 
 (async () => {
   try {
-    let token = await getData('authToken');
+    let token = await getData(TOKEN_KEY || 'authToken');
     quizAPI.defaults.headers.common['Authorization'] = token;
   } catch (error) {
     console.error(error);

--- a/src/configuration/Axios.configuration.js
+++ b/src/configuration/Axios.configuration.js
@@ -1,23 +1,18 @@
 import Axios from 'axios';
 import {getData} from '../utilities/localStorage';
 
-let token;
-
-if(!token){
-  (async () => {
-    try{
-    token = await getData('AUTH_TOKEN');
-    }catch(error){
-      console.log(error);
-    }
-
-  })();
-}
-
-export const quizAPI = Axios.create({
+let quizAPI = Axios.create({
   baseURL:
     'http://ec2-54-218-161-100.us-west-2.compute.amazonaws.com:3000/api/',
-  headers: { 
-    Authorization: token
-  },
 });
+
+(async () => {
+  try {
+    let token = await getData('authToken');
+    quizAPI.defaults.headers.common['Authorization'] = token;
+  } catch (error) {
+    console.error(error);
+  }
+})();
+
+export {quizAPI};


### PR DESCRIPTION
There were 3 issues I saw: 
1. You don't need `if(!token)`
2.  `getData('AUTH_TOKEN')` should be `getData('authToken') ` OR you have to import it from the constant from **AppContext.js** and use it like this: `getData(TOKEN_KEY)`  TOKEN_KEY is the name that Miguel used. I was receiving errors due to the wrong key name. 
3. If you're going to use the headers like how you did it, it should look like this:
`
  headers: {
    common: {
      Authorization: 'authToken'
    }
  }
`
Notice the **common** nested under headers. Additionally, we are changing token constantly, I think using `quizAPI.defaults.headers.common['Authorization'] = token`; is better than the other way. https://stackoverflow.com/questions/59712034/how-to-properly-set-axios-default-headers

Lastly, this change only works half of the time since retrieving the auth token is an **asynchronous** method. I have NOT figure a solution for this yet, but I was able to come up with a temporary fix by attaching a header directly when making API calls at the screen (e.g. ProfileScreen.js). I got the token from global context (**AppContext**.js).