### PR TITLE
Quick fix for scores on ProfileScreen.

### DIFF
--- a/src/screens/profile/ProfileScreen.js
+++ b/src/screens/profile/ProfileScreen.js
@@ -15,7 +15,7 @@ export const ProfileScreen = () => {
     name: '',
     email: '',
     image: '',
-    scores: {'0': 0},
+    scores: [0],
   });
 
   const signOut = async () => {


### PR DESCRIPTION
Putting scores into an array rather than an object.